### PR TITLE
Fix interface name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,11 @@ var cacheableQuery = cacheableContext.Books
 ### Custom Cache Provider
 
 
-Alternatively you can provide a custom implementation of `ICachingProvider` (default is `MemoryCacheProvider`).
+Alternatively you can provide a custom implementation of `ICacheProvider` (default is `MemoryCacheProvider`).
 This provides a easy option for supporting other caching systems like [![](https://redis.io/images/favicon.png) redis](https://redis.io/) or [Memcached](https://memcached.org/).
 
 ```csharp
-optionsBuilder.UseSecondLevelCache(new MyCachingProvider());
+optionsBuilder.UseSecondLevelCache(new MyCacheProvider());
 ```
 
 


### PR DESCRIPTION
According to the README, the cache provider interface is ICachingProvider when it is actually ICacheProvider. Fixing this to avoid confusion.