### PR TITLE
Add PopulateDebugInfo to allow it to work with newer EF Core

### DIFF
--- a/EntityFrameworkCore.Cacheable/CacheableOptionsExtension.cs
+++ b/EntityFrameworkCore.Cacheable/CacheableOptionsExtension.cs
@@ -19,7 +19,7 @@ namespace EntityFrameworkCore.Cacheable
 
         public bool ApplyServices(IServiceCollection services)
         {
-            services.AddSingleton<ICacheProvider>(_cacheProvider);
+            services.AddSingleton(_cacheProvider);
 
             return false;
         }
@@ -30,9 +30,15 @@ namespace EntityFrameworkCore.Cacheable
         {            
         }
 
+        public void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+        {
+            debugInfo["EntityFrameworkCore.Cacheable:" + nameof(_cacheProvider)] = _cacheProvider.GetType().ToString();
+        }
+
         /// <summary>
         ///     The option set from the <see cref="DbContextOptionsBuilder.UseSecondLevelMemoryCache" /> method.
         /// </summary>
         public virtual ICacheProvider CacheProvider => _cacheProvider;
     }
 }
+//"Method 'PopulateDebugInfo' in type 'EntityFrameworkCore.Cacheable.CacheableOptionsExtension' from assembly 'EntityFrameworkCore.Cacheable, Version=2.0.1.0, Culture=neutral, PublicKeyToken=null' does not have an implementation."


### PR DESCRIPTION
Method 'PopulateDebugInfo' in type 'EntityFrameworkCore.Cacheable.CacheableOptionsExtension' from assembly 'EntityFrameworkCore.Cacheable, Version=2.0.1.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.

This should resolve this issue and still stay backwards compatible with old versions. This also gives some debugging information for when trying to debug while things are broken or using the wrong CacheProvider.